### PR TITLE
🚸 interpreted left and rights

### DIFF
--- a/umberbar.cr
+++ b/umberbar.cr
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-VERSION = "0.4"
+VERSION = "0.5"
 
 require "./bar"
 


### PR DESCRIPTION
🚸 interpreted left and rights

Instead of having to input ANSI escape code directly into the config
file, adds an interprete step of left and rights at runtime.